### PR TITLE
Constrain ServiceLocatorManager.AsMono type to valid components.

### DIFF
--- a/Assets/Packages/ServiceLocator/ServiceLocatorManager.cs
+++ b/Assets/Packages/ServiceLocator/ServiceLocatorManager.cs
@@ -44,10 +44,10 @@ namespace ServiceLocator
             Debug.LogError(logMsg);
         }
 
-        public static Component AsMono<T>(bool destroyOnLoad = false)
+        public static T AsMono<T>(bool destroyOnLoad = false) where T : Component
         {
             GameObject gameObject = new GameObject(typeof(T).Name);
-            var obj = gameObject.AddComponent(typeof(T));
+            var obj = gameObject.AddComponent<T>();
             if (!destroyOnLoad)
             {
                 Object.DontDestroyOnLoad(gameObject);


### PR DESCRIPTION
This makes sure you can't do impossible things like adding a Mesh as a component. It will produce compile time errors instead of runtime errors.

`ServiceLocatorManager.AsMono<Mesh>();`
`The type 'UnityEngine.Mesh' must be convertible to 'UnityEngine.Component' in order to use it as parameter 'T' in the generic method 'T ServiceLocator.ServiceLocatorManager.AsMono<T>(bool)'`

Also return the more specific type so you don't have to cast it after creating it.