### PR TITLE
Implemented a way to add already setup gameobjects as a service.

### DIFF
--- a/ServiceLocatorAlreadySetupGameobjects.cs
+++ b/ServiceLocatorAlreadySetupGameobjects.cs
@@ -1,0 +1,9 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ServiceLocatorAlreadySetupGameobjects
+{
+    public GameObject ObjectToInstantiate;
+    public Transform Parent;
+}

--- a/ServiceLocatorManager.cs
+++ b/ServiceLocatorManager.cs
@@ -39,6 +39,29 @@ namespace Packages.ServiceLocator
             
             Logger?.Log(ServiceLocatorManagerLogArgs.Registered(this, typeof(T), serviceInstance));
         }
+        
+        public void Register<T>(ServiceLocatorAlreadySetupGameobjects serviceInstance,bool destroyOnLoad = true)
+        {
+            if (serviceInstance == null || serviceInstance.ObjectToInstantiate == null) 
+            {
+                return;
+            }
+
+            Transform parent = serviceInstance.Parent ? serviceInstance.Parent : null;
+            
+            GameObject objectToInstantiate = Object.Instantiate(serviceInstance.ObjectToInstantiate, parent);
+            
+            var mainService = objectToInstantiate.GetComponent<T>();
+            
+            if (!destroyOnLoad)
+            {
+                Object.DontDestroyOnLoad(objectToInstantiate);
+            }
+            
+            services[typeof(T)] = mainService;
+            
+            Logger?.Log(ServiceLocatorManagerLogArgs.Registered(this, typeof(T), mainService));
+        }
 
         public T Resolve<T>()
         {

--- a/ServiceLocatorManager.cs
+++ b/ServiceLocatorManager.cs
@@ -40,7 +40,7 @@ namespace Packages.ServiceLocator
             Logger?.Log(ServiceLocatorManagerLogArgs.Registered(this, typeof(T), serviceInstance));
         }
         
-        public void Register<T>(ServiceLocatorAlreadySetupGameobjects serviceInstance,bool destroyOnLoad = true)
+        public void Register<T>(ServiceLocatorPrefab serviceInstance,bool destroyOnLoad = true)
         {
             if (serviceInstance == null || serviceInstance.ObjectToInstantiate == null) 
             {

--- a/ServiceLocatorManager.cs
+++ b/ServiceLocatorManager.cs
@@ -47,7 +47,7 @@ namespace Packages.ServiceLocator
                 return;
             }
 
-            Transform parent = serviceInstance.Parent ? serviceInstance.Parent : null;
+            Transform parent = serviceInstance.Parent;
             
             GameObject objectToInstantiate = Object.Instantiate(serviceInstance.ObjectToInstantiate, parent);
             

--- a/ServiceLocatorPrefab.cs
+++ b/ServiceLocatorPrefab.cs
@@ -2,7 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ServiceLocatorAlreadySetupGameobjects
+public class ServiceLocatorPrefab
 {
     public GameObject ObjectToInstantiate;
     public Transform Parent;

--- a/ServiceLocatorPrefab.cs.meta
+++ b/ServiceLocatorPrefab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83a34582a5719194996e55798c3f8aaa
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/ServiceLocatorTests.cs
+++ b/Tests/ServiceLocatorTests.cs
@@ -62,6 +62,45 @@ namespace Tests
             var serviceExists = serviceLocatorManager.ServiceExists<IMockInterface>();
             Assert.IsTrue(serviceExists);
         }
+        
+        [Test]
+        public void UseAlreadySetupPrefabs()
+        {
+            var serviceLocatorPrefab = new ServiceLocatorPrefab();
+            
+            var testPrefab = new GameObject("TestGameObject");
+            var alreadyAssignedInPrefab = new GameObject("GameObjectAssigned to Prefab in Editor");
+            var component = testPrefab.AddComponent<MockServiceLocatorPrefab>();
+            component.AlreadyAssignedInPrefab = alreadyAssignedInPrefab;
+
+            serviceLocatorPrefab.ObjectToInstantiate = testPrefab;
+            
+            serviceLocatorManager.Register<MockServiceLocatorPrefab>(serviceLocatorPrefab);
+            var resolvedObject = serviceLocatorManager.Resolve<MockServiceLocatorPrefab>();
+
+            Assert.IsTrue(resolvedObject.AlreadyAssignedInPrefab == component.AlreadyAssignedInPrefab);
+        }
+        
+        [Test]
+        public void UseAlreadySetupPrefabsWithParents()
+        {
+            var serviceLocatorPrefab = new ServiceLocatorPrefab();
+            
+            var testPrefab = new GameObject("TestGameObject");
+            var testPrefabParent = new GameObject("TestGameObjectParent");
+            
+            var alreadyAssignedInPrefab = new GameObject("GameObjectAssigned to Prefab in Editor");
+            var component = testPrefab.AddComponent<MockServiceLocatorPrefab>();
+            component.AlreadyAssignedInPrefab = alreadyAssignedInPrefab;
+
+            serviceLocatorPrefab.ObjectToInstantiate = testPrefab;
+            serviceLocatorPrefab.Parent = testPrefabParent.transform;
+            
+            serviceLocatorManager.Register<MockServiceLocatorPrefab>(serviceLocatorPrefab);
+            var resolvedObject = serviceLocatorManager.Resolve<MockServiceLocatorPrefab>();
+
+            Assert.IsTrue(resolvedObject.transform.parent ==  serviceLocatorPrefab.Parent );
+        }
 
         [Test]
         public void CreateMonoServiceResetItAndResolveIt()

--- a/Tests/utils/MockServiceLocatorPrefab.cs
+++ b/Tests/utils/MockServiceLocatorPrefab.cs
@@ -1,0 +1,8 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class MockServiceLocatorPrefab : MonoBehaviour, IMockInterface
+{
+    public GameObject AlreadyAssignedInPrefab;
+}

--- a/Tests/utils/MockServiceLocatorPrefab.cs.meta
+++ b/Tests/utils/MockServiceLocatorPrefab.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d0683a076832004e9be262edf5dd59f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION

Implemented a way to add already setup gameobjects as a service. You can do this by creating a new instance of a class, assigning the gameobject to be created, a parent if needed, and the type. 

The servicelocator manager will instantiate the gameobject from that class and save to the dictionary using the type passed into the method.